### PR TITLE
Ignore older than and commit time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Following configuration parameters are supported by the _git-changelog-maven-plu
 * GitHub repository URL to be used. If present commit messages containing GitHub pull request references are extended
 with relevant details.
 
+**ignoreOlderThen**, _optional_
+* Ignore commits older than date (format: YYYY-MM-dd HH:mm:ss)
+
 ### Automatic change log generation during Maven release
 
 You can configure Maven release plugin to update change log with each release. 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The _git-changelog-maven-plugin_ provides following data structures to _Mustache
             - title
             - shortHash
             - commitLink
+            - commitTime
         - extensions
             - jira
                 * title

--- a/src/main/java/info/plichta/maven/plugins/changelog/ChangeLogMojo.java
+++ b/src/main/java/info/plichta/maven/plugins/changelog/ChangeLogMojo.java
@@ -31,6 +31,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -78,6 +79,9 @@ public class ChangeLogMojo extends AbstractMojo {
     @Parameter(property = "project.artifactId")
     private String tagPrefix;
 
+    @Parameter
+    private Date ignoreOlderThen;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         final String template = Optional.of(templateFile)
@@ -86,7 +90,7 @@ public class ChangeLogMojo extends AbstractMojo {
                 .orElse(DEFAULT_TEMPLATE);
 
         final ChangeLogWriter logGenerator = new ChangeLogWriter(template, getLog());
-        final CommitFilter commitFilter = new CommitFilter(includeCommits, excludeCommits);
+        final CommitFilter commitFilter = new CommitFilter(includeCommits, excludeCommits, ignoreOlderThen);
 
         final List<CommitHandler> commitHandlers = new ArrayList<>();
         if (gitHubUrl != null) {

--- a/src/main/java/info/plichta/maven/plugins/changelog/ChangeLogMojo.java
+++ b/src/main/java/info/plichta/maven/plugins/changelog/ChangeLogMojo.java
@@ -18,10 +18,10 @@
 package info.plichta.maven.plugins.changelog;
 
 import info.plichta.maven.plugins.changelog.handlers.CommitHandler;
-import info.plichta.maven.plugins.changelog.model.ChangeLog;
-import info.plichta.maven.plugins.changelog.model.TagWrapper;
 import info.plichta.maven.plugins.changelog.handlers.JiraHandler;
 import info.plichta.maven.plugins.changelog.handlers.PullRequestHandler;
+import info.plichta.maven.plugins.changelog.model.ChangeLog;
+import info.plichta.maven.plugins.changelog.model.TagWrapper;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -30,8 +30,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -80,7 +80,7 @@ public class ChangeLogMojo extends AbstractMojo {
     private String tagPrefix;
 
     @Parameter
-    private Date ignoreOlderThen;
+    private LocalDateTime ignoreOlderThen;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/src/main/java/info/plichta/maven/plugins/changelog/CommitFilter.java
+++ b/src/main/java/info/plichta/maven/plugins/changelog/CommitFilter.java
@@ -19,6 +19,7 @@ package info.plichta.maven.plugins.changelog;
 
 import org.eclipse.jgit.revwalk.RevCommit;
 
+import java.util.Date;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -26,15 +27,30 @@ import java.util.regex.Pattern;
 public class CommitFilter implements Predicate<RevCommit> {
     private final Predicate<RevCommit> predicate;
 
-    CommitFilter(String include, String exclude) {
+    private static final long MILLISECONDS = 1000;
+
+    CommitFilter(final String include, final String exclude, final Date ignoreOlderThen) {
         final Pattern includePattern = Pattern.compile(include, Pattern.MULTILINE | Pattern.DOTALL);
         final Optional<Pattern> excludePattern = Optional.ofNullable(exclude).map((regex) -> Pattern.compile(regex, Pattern.MULTILINE | Pattern.DOTALL));
+
 
         final Predicate<RevCommit> includePred =
                 revCommit -> includePattern.matcher(revCommit.getFullMessage()).matches();
         final Predicate<RevCommit> excludePred =
                 revCommit -> excludePattern.map(p -> p.matcher(revCommit.getFullMessage()).matches()).orElse(false);
-        predicate = includePred.and(excludePred.negate());
+        final int maxTime = getMinimumCommitTime(ignoreOlderThen);
+        final Predicate<RevCommit> timePred = revCommit -> revCommit.getCommitTime() >= maxTime;
+
+
+        predicate = includePred.and(excludePred.negate()).and(timePred);
+    }
+
+    private int getMinimumCommitTime(Date ignoreOlderThen) {
+        if (ignoreOlderThen != null) {
+            return (int) (ignoreOlderThen.getTime() / MILLISECONDS);
+        } else {
+            return 0;
+        }
     }
 
     @Override

--- a/src/main/java/info/plichta/maven/plugins/changelog/model/CommitWrapper.java
+++ b/src/main/java/info/plichta/maven/plugins/changelog/model/CommitWrapper.java
@@ -19,10 +19,8 @@ package info.plichta.maven.plugins.changelog.model;
 
 import org.eclipse.jgit.revwalk.RevCommit;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 import static org.apache.commons.lang3.StringUtils.left;
 import static org.apache.commons.lang3.StringUtils.stripEnd;
@@ -31,6 +29,12 @@ import static org.apache.commons.lang3.StringUtils.stripEnd;
  * Model class representing one GIT commit.
  */
 public class CommitWrapper {
+
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private static final long MILLISECONDS = 1000L;
+
+
     private final String gitHubUrl;
     private final RevCommit commit;
     private String title;
@@ -70,5 +74,9 @@ public class CommitWrapper {
 
     public Map<String, Object> getExtensions() {
         return extensions;
+    }
+
+    public String getCommitTime() {
+        return DATE_FORMAT.format(new Date(commit.getCommitTime() * MILLISECONDS));
     }
 }

--- a/src/main/java/info/plichta/maven/plugins/changelog/model/CommitWrapper.java
+++ b/src/main/java/info/plichta/maven/plugins/changelog/model/CommitWrapper.java
@@ -19,8 +19,13 @@ package info.plichta.maven.plugins.changelog.model;
 
 import org.eclipse.jgit.revwalk.RevCommit;
 
-import java.text.SimpleDateFormat;
-import java.util.*;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.left;
 import static org.apache.commons.lang3.StringUtils.stripEnd;
@@ -29,11 +34,8 @@ import static org.apache.commons.lang3.StringUtils.stripEnd;
  * Model class representing one GIT commit.
  */
 public class CommitWrapper {
-
-
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final long MILLISECONDS = 1000L;
-
 
     private final String gitHubUrl;
     private final RevCommit commit;
@@ -77,6 +79,6 @@ public class CommitWrapper {
     }
 
     public String getCommitTime() {
-        return DATE_FORMAT.format(new Date(commit.getCommitTime() * MILLISECONDS));
+        return Instant.ofEpochMilli(commit.getCommitTime() * MILLISECONDS).atZone(ZoneId.systemDefault()).toLocalDateTime().format(DATE_FORMAT);
     }
 }

--- a/src/test/java/info/plichta/maven/plugins/changelog/CommitFilterTest.java
+++ b/src/test/java/info/plichta/maven/plugins/changelog/CommitFilterTest.java
@@ -23,6 +23,8 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Date;
+
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -42,29 +44,43 @@ public class CommitFilterTest extends RepositoryTestCase {
 
     @Test
     public void testIncludeAllNoExclude() throws Exception {
-        final CommitFilter filter = new CommitFilter(".*", null);
+        final CommitFilter filter = new CommitFilter(".*", null,null);
         assertThat(filter.test(commit), is(true));
         assertThat(filter.test(commit2), is(true));
     }
 
     @Test
     public void testExcludeAll() {
-        final CommitFilter filter = new CommitFilter(".*", ".*");
+        final CommitFilter filter = new CommitFilter(".*", ".*",null);
         assertThat(filter.test(commit), is(false));
         assertThat(filter.test(commit2), is(false));
     }
 
     @Test
     public void testIncludeNone() {
-        final CommitFilter filter = new CommitFilter("", null);
+        final CommitFilter filter = new CommitFilter("", null,null);
         assertThat(filter.test(commit), is(false));
         assertThat(filter.test(commit2), is(false));
     }
 
     @Test
     public void testExcludeSome() {
-        final CommitFilter filter = new CommitFilter(".*", ".*i.*");
+        final CommitFilter filter = new CommitFilter(".*", ".*i.*",null);
         assertThat(filter.test(commit), is(false));
+        assertThat(filter.test(commit2), is(true));
+    }
+
+    @Test
+    public void testExcludeAllByTime() {
+        final CommitFilter filter = new CommitFilter(".*", null,new Date());
+        assertThat(filter.test(commit), is(false));
+        assertThat(filter.test(commit2), is(false));
+    }
+
+    @Test
+    public void testIncludeAllByTime() {
+        final CommitFilter filter = new CommitFilter(".*", null,new Date(1));
+        assertThat(filter.test(commit), is(true));
         assertThat(filter.test(commit2), is(true));
     }
 

--- a/src/test/java/info/plichta/maven/plugins/changelog/CommitFilterTest.java
+++ b/src/test/java/info/plichta/maven/plugins/changelog/CommitFilterTest.java
@@ -23,7 +23,7 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -39,49 +39,49 @@ public class CommitFilterTest extends RepositoryTestCase {
         try (Git git = new Git(db)) {
             commit = git.commit().setMessage("Commit").call();
             commit2 = git.commit().setMessage("Test").call();
+
         }
     }
 
     @Test
     public void testIncludeAllNoExclude() throws Exception {
-        final CommitFilter filter = new CommitFilter(".*", null,null);
+        final CommitFilter filter = new CommitFilter(".*", null, null);
         assertThat(filter.test(commit), is(true));
         assertThat(filter.test(commit2), is(true));
     }
 
     @Test
     public void testExcludeAll() {
-        final CommitFilter filter = new CommitFilter(".*", ".*",null);
+        final CommitFilter filter = new CommitFilter(".*", ".*", null);
         assertThat(filter.test(commit), is(false));
         assertThat(filter.test(commit2), is(false));
     }
 
     @Test
     public void testIncludeNone() {
-        final CommitFilter filter = new CommitFilter("", null,null);
+        final CommitFilter filter = new CommitFilter("", null, null);
         assertThat(filter.test(commit), is(false));
         assertThat(filter.test(commit2), is(false));
     }
 
     @Test
     public void testExcludeSome() {
-        final CommitFilter filter = new CommitFilter(".*", ".*i.*",null);
+        final CommitFilter filter = new CommitFilter(".*", ".*i.*", null);
         assertThat(filter.test(commit), is(false));
         assertThat(filter.test(commit2), is(true));
     }
 
     @Test
     public void testExcludeAllByTime() {
-        final CommitFilter filter = new CommitFilter(".*", null,new Date());
+        final CommitFilter filter = new CommitFilter(".*", null, LocalDateTime.now());
         assertThat(filter.test(commit), is(false));
         assertThat(filter.test(commit2), is(false));
     }
 
     @Test
     public void testIncludeAllByTime() {
-        final CommitFilter filter = new CommitFilter(".*", null,new Date(1));
+        final CommitFilter filter = new CommitFilter(".*", null, LocalDateTime.of(2000, 12, 1, 0, 0));
         assertThat(filter.test(commit), is(true));
         assertThat(filter.test(commit2), is(true));
     }
-
 }


### PR DESCRIPTION
Add ignore-older-than config option. 
Commit time added to CommitWrapper and available in template.
