### PR TITLE
FEATURE: introduce native skip option via <skip> configuration parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>info.plichta.maven.plugins</groupId>
     <artifactId>git-changelog-maven-plugin</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>${project.artifactId}</name>
     <description>git changelog plugin</description>

--- a/src/main/java/info/plichta/maven/plugins/changelog/ChangeLogMojo.java
+++ b/src/main/java/info/plichta/maven/plugins/changelog/ChangeLogMojo.java
@@ -82,8 +82,15 @@ public class ChangeLogMojo extends AbstractMojo {
     @Parameter
     private LocalDateTime ignoreOlderThen;
 
+    @Parameter(defaultValue = "false")
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            return;     // execution skipped
+        }
+
         final String template = Optional.of(templateFile)
                 .filter(File::canRead)
                 .map(File::toString)


### PR DESCRIPTION
Most of maven plugins supports execution skiping via `<skip>` configuration parameter. This option is very useful for multi-module projects.